### PR TITLE
Added code for using matrix multiplexing

### DIFF
--- a/Buttons.cpp
+++ b/Buttons.cpp
@@ -1,116 +1,19 @@
-#include <Arduino.h>
 #include "PINS.h"
 #include "Buttons.h"
+#include "ShiftRegisterButtons.h"
+#include "MatrixButtons.h"
 
-
-byte Buttons::m_pMap[] = // eg logical eBit2 is actually bit6 from the 165
-{
-  0, 1, 6, 7, 4, 5, 2, 3,
-  11, 12, 13, 14, 15, 9, 8, 10
-};
-
-void Buttons::Init()
-{
-  // prepare the pins which talk to the 165
-  pinMode(PIN_BTN_PL, OUTPUT);
-  pinMode(PIN_BTN_CP, OUTPUT); 
-  pinMode(PIN_BTN_Q7, INPUT);
-  // set no prev state
-  m_wPrevState = 0xFFFF;
-  m_wPrevReading = 0xFFFF;
-  m_iTransitionTimeMS = millis();
-}
-
-word Buttons::ShiftIn(int LatchPin, int DataPin, int ClockPin, int BitOrder)
-{
-  // read 16 bits of button statuses
-  digitalWrite(ClockPin, HIGH);   // "Either the CP or the !CE should be HIGH before the LOW-to-HIGH transition of PL to prevent shifting the data when PL is activated."
-
-  digitalWrite(LatchPin, LOW);  // latch the switch states
-  digitalWrite(LatchPin, HIGH);  // shift data in when this is high and on a +ve going clock, HOWEVER, shiftIn uses High->Low?
-  
-  byte First  = shiftIn(DataPin, ClockPin, BitOrder);
-  byte Second = shiftIn(DataPin, ClockPin, BitOrder);
-  return word(Second, First);
-}
-
-#if 0
-// Time-based debouncing, ifdef'd out because I'm not sure of the impact on execution
-bool Buttons::GetButtons(word& State, word& NewPressed, bool deBounce)
-{
-  // get the current raw state and any that have changed to down
-  unsigned long nowMS = millis();
-  word ThisState = ShiftIn(PIN_BTN_PL, PIN_BTN_Q7, PIN_BTN_CP, MSBFIRST);
-  bool deBounced = !deBounce;
-  if (deBounce)
-  {
-      if (ThisState != m_wPrevReading)
-      {
-        // state change, reset the timer
-        m_wPrevReading = ThisState;
-        m_iTransitionTimeMS = nowMS;
-      }
-      else if ((nowMS - m_iTransitionTimeMS) >= 20UL)
-      {
-          // held for long enough
-          deBounced = true;
-      }
-  }
-  
-  if (ThisState != m_wPrevState && deBounced)
-  {
-    NewPressed = ThisState & (~m_wPrevState);  // only those that have *changed* from OFF to ON, i.e. DOWN
-
-    m_wPrevState = ThisState;
-    State = ThisState;
-    return true;
-  }
-  return false;
-}
+#if defined(USE_MATRIX_FRONT_PANEL) && USE_MATRIX_FRONT_PANEL
+#define ACTIVE_BUTTONS_MATRIX 1
 #else
-bool Buttons::GetButtons(word& State, word& NewPressed, bool Wait)
-{
-  // get the current raw state and any that have changed to down
-  word ThisState = ShiftIn(PIN_BTN_PL, PIN_BTN_Q7, PIN_BTN_CP, MSBFIRST);
-  
-  if (Wait)
-  {
-    // simple de-bounce, if requested
-    delay(20);
-    word DebouncedState = ShiftIn(PIN_BTN_PL, PIN_BTN_Q7, PIN_BTN_CP, MSBFIRST);
-    if (DebouncedState != ThisState)
-      return false;
-  }
-  
-  if (ThisState != m_wPrevState)
-  {
-    NewPressed = ThisState & (~m_wPrevState);  // only those that have *changed* from OFF to ON, i.e. DOWN
-
-    m_wPrevState = ThisState;
-    State = ThisState;
-    return true;
-  }
-  return false;
-}
+#define ACTIVE_BUTTONS_MATRIX 0
 #endif
 
-bool Buttons::IsPressed(word BtnState, int Btn)
-{
-  // is the Btn down (in the given state)
-  return bitRead(BtnState, m_pMap[Btn]);
-}
+static ShiftRegisterButtons g_shiftRegisterButtons;
+static MatrixButtons g_matrixButtons;
 
-bool Buttons::GetButtonDown(word BtnState, int& Btn)
-{
-  // return the first Btn down in the state
-  for (Btn = eBit0; Btn <= eUnused; Btn++)
-  {
-    if (IsPressed(BtnState, Btn))
-      return true;
-  }
-  return false;
-}
-
-
-Buttons buttons = Buttons();
-
+#if ACTIVE_BUTTONS_MATRIX
+Buttons& buttons = g_matrixButtons;
+#else
+Buttons& buttons = g_shiftRegisterButtons;
+#endif

--- a/Buttons.h
+++ b/Buttons.h
@@ -1,10 +1,10 @@
 #ifndef buttons_h
 #define buttons_h
 
+#include <Arduino.h>
 
 // buttons/switches
-// Interacts with the 15 (8 data, 7 control) push-buttons via
-// daisy-chained 74HC165's
+// Abstract interface for reading the 15 (8 data, 7 control) push-buttons.
 class Buttons
 {
 public:
@@ -29,22 +29,13 @@ public:
     eUnused
   };
 
-  void Init();
+  virtual ~Buttons() {}
 
-  bool GetButtons(word& State, word& NewPressed, bool deBounce);
-  bool IsPressed(word BtnState, int Btn);
-  bool GetButtonDown(word BtnState, int& Btn);
-
-private:
-  word ShiftIn(int LatchPin, int DataPin, int ClockPin, int BitOrder);
-  static byte m_pMap[];
-  word m_wPrevState;
-  
-  word m_wPrevReading;
-  unsigned long m_iTransitionTimeMS;
+  virtual void Init() = 0;
+  virtual bool GetButtons(word& State, word& NewPressed, bool deBounce) = 0;
+  virtual bool IsPressed(word BtnState, int Btn) = 0;
+  virtual bool GetButtonDown(word BtnState, int& Btn) = 0;
 };
 
-extern Buttons buttons;
+extern Buttons& buttons;
 #endif
-
-

--- a/LEDS.cpp
+++ b/LEDS.cpp
@@ -1,71 +1,19 @@
-#include <Arduino.h>
 #include "PINS.h"
-#include "MCP.h"
 #include "LEDS.h"
- 
-void LEDs::Init()
-{
-  // the 595 controls the 8 data LEDs
-  pinMode(PIN_LEDS_DS, OUTPUT);
-  pinMode(PIN_LEDS_ST, OUTPUT);
-  pinMode(PIN_LEDS_SH, OUTPUT);
-  ShiftOut(0x00);
-  m_LastData = 0;
+#include "ShiftRegisterLEDs.h"
+#include "MatrixLEDs.h"
 
-  // the 4 control LEDs have a direct link
-  for (int Pin = MCP::eInput; Pin <= MCP::eRun; Pin++)
-  {
-    pinMode(m_pDirectControlPins[Pin], OUTPUT);
-    digitalWrite(m_pDirectControlPins[Pin], LOW);
-  }
-  m_LastControl = 0;
-}
+#if defined(USE_MATRIX_FRONT_PANEL) && USE_MATRIX_FRONT_PANEL
+#define ACTIVE_LEDS_MATRIX 1
+#else
+#define ACTIVE_LEDS_MATRIX 0
+#endif
 
-void LEDs::ShiftOut(byte LEDs)
-{
-  digitalWrite(PIN_LEDS_ST, LOW);
-  // shift out the bits to the 595:
-  shiftOut(PIN_LEDS_DS, PIN_LEDS_SH, LSBFIRST, LEDs);  // LSBFIRST because Q0 == Bit7
-  // take the latch pin high so the LEDs will light up:
-  digitalWrite(PIN_LEDS_ST, HIGH);
-}
+static ShiftRegisterLEDs g_shiftRegisterLEDs;
+static MatrixLEDs g_matrixLEDs;
 
-void LEDs::Display(byte Data, byte Control)
-{
-  // update the data and control LEDs
-  if (Data != m_LastData)
-  {
-    ShiftOut(Data);
-    m_LastData = Data;
-  }
-  
-  if (Control != m_LastControl)
-  {
-    for (int Pin = MCP::eInput; Pin < MCP::eRun; Pin++)
-    {
-      digitalWrite(m_pDirectControlPins[Pin], bitRead(Control, Pin)?HIGH:LOW);
-    }
-    
-    if (bitRead(Control, MCP::eRun))
-    {
-      // the Run LED can do PWM, use the upper 4 bits; 0000 = max brightness (255) 1111 = min (16)
-      analogWrite(m_pDirectControlPins[MCP::eRun], 0xFF - (Control & 0xF0));
-    }
-    else
-    {
-      digitalWrite(m_pDirectControlPins[MCP::eRun], LOW);
-    }
-    m_LastControl = Control;
-  }
-}
-
-// pin mapping in the same order as MCP::tMode
-byte LEDs::m_pDirectControlPins[] =
-{
-  PIN_LED_INP,
-  PIN_LED_ADDR,
-  PIN_LED_MEM,
-  PIN_LED_RUN_PWM
-};
-
-LEDs leds = LEDs();
+#if ACTIVE_LEDS_MATRIX
+LEDs& leds = g_matrixLEDs;
+#else
+LEDs& leds = g_shiftRegisterLEDs;
+#endif

--- a/LEDS.h
+++ b/LEDS.h
@@ -1,22 +1,18 @@
 #ifndef leds_h
 #define leds_h
+
+#include <Arduino.h>
  
-// control the 12 LEDs via a 74HC595 and direct control
+// Abstract interface for controlling the 12 front-panel LEDs.
 
 class LEDs
 {
 public:
-  void Init();
-  void Display(byte Data, byte Control);
+  virtual ~LEDs() {}
 
-private:
-  void ShiftOut(byte LEDs);
-
-  static byte m_pDirectControlPins[];
-  byte m_LastData;
-  byte m_LastControl;
+  virtual void Init() = 0;
+  virtual void Display(byte Data, byte Control) = 0;
 };
 
-extern LEDs leds;
+extern LEDs& leds;
 #endif
-

--- a/MatrixButtons.cpp
+++ b/MatrixButtons.cpp
@@ -1,0 +1,67 @@
+#include <Arduino.h>
+#include "MatrixButtons.h"
+#include "PanelMux.h"
+
+byte MatrixButtons::m_pMap[] = // direct map for banked matrix scan slots
+{
+  0, 1, 2, 3, 4, 5, 6, 7,
+  8, 9, 10, 11, 12, 13, 14, 15
+};
+
+void MatrixButtons::Init()
+{
+  PanelMux::Init();
+
+  // set no prev state
+  m_wPrevState = 0xFFFF;
+}
+
+word MatrixButtons::ReadMatrixState()
+{
+  // 16 logical slots: bank0(8 switches) + bank1(8 switches)
+  byte Bank0 = PanelMux::ReadButtons(0);
+  byte Bank1 = PanelMux::ReadButtons(1);
+  return word(Bank1, Bank0);
+}
+
+bool MatrixButtons::GetButtons(word& State, word& NewPressed, bool Wait)
+{
+  // get the current raw state and any that have changed to down
+  word ThisState = ReadMatrixState();
+  
+  if (Wait)
+  {
+    // simple de-bounce, if requested
+    delay(20);
+    word DebouncedState = ReadMatrixState();
+    if (DebouncedState != ThisState)
+      return false;
+  }
+  
+  if (ThisState != m_wPrevState)
+  {
+    NewPressed = ThisState & (~m_wPrevState);  // only those that have *changed* from OFF to ON, i.e. DOWN
+
+    m_wPrevState = ThisState;
+    State = ThisState;
+    return true;
+  }
+  return false;
+}
+
+bool MatrixButtons::IsPressed(word BtnState, int Btn)
+{
+  // is the Btn down (in the given state)
+  return bitRead(BtnState, m_pMap[Btn]);
+}
+
+bool MatrixButtons::GetButtonDown(word BtnState, int& Btn)
+{
+  // return the first Btn down in the state
+  for (Btn = eBit0; Btn <= eUnused; Btn++)
+  {
+    if (IsPressed(BtnState, Btn))
+      return true;
+  }
+  return false;
+}

--- a/MatrixButtons.h
+++ b/MatrixButtons.h
@@ -1,0 +1,21 @@
+#ifndef matrix_buttons_h
+#define matrix_buttons_h
+
+#include "Buttons.h"
+
+// Matrix front-panel implementation (two banks, shared IO lines).
+class MatrixButtons : public Buttons
+{
+public:
+  virtual void Init();
+  virtual bool GetButtons(word& State, word& NewPressed, bool deBounce);
+  virtual bool IsPressed(word BtnState, int Btn);
+  virtual bool GetButtonDown(word BtnState, int& Btn);
+
+private:
+  word ReadMatrixState();
+  static byte m_pMap[];
+  word m_wPrevState;
+};
+
+#endif

--- a/MatrixLEDs.cpp
+++ b/MatrixLEDs.cpp
@@ -1,0 +1,49 @@
+#include <Arduino.h>
+#include "MCP.h"
+#include "MatrixLEDs.h"
+#include "PanelMux.h"
+
+void MatrixLEDs::Init()
+{
+  PanelMux::Init();
+
+  m_LastData = 0;
+  m_LastControl = 0;
+  Refresh();
+}
+
+void MatrixLEDs::Refresh()
+{
+  // Bank 0 carries data LEDs bit0..bit5.
+  byte Bank0 = 0;
+  bitWrite(Bank0, 0, bitRead(m_LastData, 0));
+  bitWrite(Bank0, 1, bitRead(m_LastData, 1));
+  bitWrite(Bank0, 2, bitRead(m_LastData, 2));
+  bitWrite(Bank0, 3, bitRead(m_LastData, 3));
+  bitWrite(Bank0, 4, bitRead(m_LastData, 4));
+  bitWrite(Bank0, 5, bitRead(m_LastData, 5));
+
+  // Bank 1 carries data bit6..bit7 and control LEDs INP/ADDR/MEM/RUN.
+  byte Bank1 = 0;
+  bitWrite(Bank1, 0, bitRead(m_LastData, 6));
+  bitWrite(Bank1, 1, bitRead(m_LastData, 7));
+  bitWrite(Bank1, 2, bitRead(m_LastControl, MCP::eInput));
+  bitWrite(Bank1, 3, bitRead(m_LastControl, MCP::eAddress));
+  bitWrite(Bank1, 4, bitRead(m_LastControl, MCP::eMemory));
+  bitWrite(Bank1, 5, bitRead(m_LastControl, MCP::eRun));
+
+  PanelMux::WriteLEDs(0, Bank0);
+  PanelMux::WriteLEDs(1, Bank1);
+}
+
+void MatrixLEDs::Display(byte Data, byte Control)
+{
+  if (Data != m_LastData || Control != m_LastControl)
+  {
+    m_LastData = Data;
+    m_LastControl = Control;
+  }
+
+  // Always refresh so multiplexed LEDs stay active.
+  Refresh();
+}

--- a/MatrixLEDs.h
+++ b/MatrixLEDs.h
@@ -1,0 +1,20 @@
+#ifndef matrix_leds_h
+#define matrix_leds_h
+
+#include "LEDS.h"
+
+// Matrix implementation: two banks with shared LED lines.
+class MatrixLEDs : public LEDs
+{
+public:
+  virtual void Init();
+  virtual void Display(byte Data, byte Control);
+
+private:
+  void Refresh();
+
+  byte m_LastData;
+  byte m_LastControl;
+};
+
+#endif

--- a/PINS.h
+++ b/PINS.h
@@ -1,11 +1,15 @@
 #ifndef pins_h
 #define pins_h
+
+// 1 = matrix front panel, 0 = shift-register front panel.
+#define USE_MATRIX_FRONT_PANEL 1
  
 // Pin assignments
 // DS1307 - RTC (wire library)
 #define PIN_RTC_SDA	A4
 #define PIN_RTC_SCL	A5
 
+// Shift-register front-panel pins (74HC595 and 74HC165 x2)
 // 74HC595 - LED driver
 #define PIN_LEDS_DS	8
 #define PIN_LEDS_ST	9
@@ -97,5 +101,68 @@ SWx:
 This reflects the order I wired my switches to '165 pins.  
 You are free to change this to match the physical arrangement of the buttons, 
 BUT you will need to also change Buttons::m_pMap[] to match.
+*********************************************************/
+
+
+// Front-panel matrix shared lines
+// The matrix front panel is split into two banks.
+// The select lines enable one bank at a time via external transistor drivers.
+// When a bank is selected:
+//   - the 8 button input lines read the switch states for that bank
+//   - the 6 LED output lines drive the LEDs for that bank
+// Bank 0 is used for the 8 data-entry buttons and the lower 6 data LEDs.
+// Bank 1 is used for the 7 control buttons plus one spare input,
+// and for the upper 2 data LEDs plus the 4 control LEDs.
+#define PIN_PANEL_SEL0	12
+#define PIN_PANEL_SEL1	13
+
+// 6 shared LED output lines (driven into selected bank)
+#define PIN_LED_0	8
+#define PIN_LED_1	9
+#define PIN_LED_2	10
+#define PIN_LED_3	11
+#define PIN_LED_4	A2
+#define PIN_LED_5	A3
+
+// 8 shared switch input lines (read from selected bank)
+#define PIN_BTN_0	2
+#define PIN_BTN_1	3
+#define PIN_BTN_2	4
+#define PIN_BTN_3	5
+#define PIN_BTN_4	6
+#define PIN_BTN_5	7
+#define PIN_BTN_6	A0
+#define PIN_BTN_7	A1
+
+/*********************************************************
+This build uses a two-bank front-panel matrix:
+  - Two select lines drive panel-bank selection via transistor drivers.
+  - 8 input lines read switches from the selected bank.
+  - 6 output lines drive LEDs on the selected bank.
+
+
+               +-------------------------+---------------+
+               | +-----------+     BANK0 |         BANK1 |
+               | |    328    |           |               |
+  <USB>--[+5V]-+-+Vcc      13+-----------|-------------|<  NPN
+  <USB>--[+5V]---+AVcc     12+---------|<  NPN           |
+  <USB>--[GND]---+Gnd(22)    |           |               |
+  <USB>--[GND]---+Gnd(8)    8+----<LED0 "Bit0">---<LED6 "Bit6">
+  <USB>---[TX]---+TX        9+----<LED1 "Bit1">---<LED7 "Bit7">
+  <USB>---[RX]---+RX       10+----<LED2 "Bit2">---<LED8 "ADDR">
+                 |         11+----<LED3 "Bit3">---<LED9 "MEM">
+      [XTAL1]----+XT1      A2+----<LED4 "Bit4">---<LED10 "INP">
+      [XTAL2]----+XT2      A3+----<LED5 "Bit5">---<LED11 "RUN">
+                 |           |           |               |
++------+         |          2+----<SW0 "Bit0">----<SW8 "STOP">
+| RTC  |         |          3+----<SW1 "Bit1">----<SW9 "STRT">
+|   SDA+---------+A4        4+----<SW2 "Bit6">----<SW10 "CLR">
+|   SCL+---------+A5        5+----<SW3 "Bit7">----<SW11 "DISP">
+|   Vcc+-[+5V]   |          6+----<SW4 "Bit4">----<SW12 "SET">
+|   Gnd+-[GND]   |          7+----<SW5 "Bit5">----<SW13 "READ">
++------+         |         A0+----<SW6 "Bit2">----<SW14 "STOR">
+                 |         A1+----<SW7 "Bit3">----<SW15 "UNUSED">
+                 |           |
+                 +-----------+
 *********************************************************/
 #endif

--- a/PanelMux.cpp
+++ b/PanelMux.cpp
@@ -1,0 +1,82 @@
+#include <Arduino.h>
+#include "PINS.h"
+#include "PanelMux.h"
+
+bool PanelMux::m_Initialized = false;
+
+static const byte kButtonPins[8] =
+{
+  PIN_BTN_0,
+  PIN_BTN_1,
+  PIN_BTN_2,
+  PIN_BTN_3,
+  PIN_BTN_4,
+  PIN_BTN_5,
+  PIN_BTN_6,
+  PIN_BTN_7
+};
+
+static const byte kLEDPins[6] =
+{
+  PIN_LED_0,
+  PIN_LED_1,
+  PIN_LED_2,
+  PIN_LED_3,
+  PIN_LED_4,
+  PIN_LED_5
+};
+
+void PanelMux::Init()
+{
+  if (m_Initialized)
+    return;
+
+  pinMode(PIN_PANEL_SEL0, OUTPUT);
+  pinMode(PIN_PANEL_SEL1, OUTPUT);
+
+  for (byte i = 0; i < 8; i++)
+  {
+    pinMode(kButtonPins[i], INPUT);
+  }
+
+  for (byte i = 0; i < 6; i++)
+  {
+    pinMode(kLEDPins[i], OUTPUT);
+    digitalWrite(kLEDPins[i], LOW);
+  }
+
+  SelectBank(0);
+  m_Initialized = true;
+}
+
+void PanelMux::SelectBank(byte Bank)
+{
+  // Two independent select lines; only one should be active at a time.
+  digitalWrite(PIN_PANEL_SEL0, Bank == 0 ? HIGH : LOW);
+  digitalWrite(PIN_PANEL_SEL1, Bank == 1 ? HIGH : LOW);
+}
+
+byte PanelMux::ReadButtons(byte Bank)
+{
+  SelectBank(Bank);
+
+  byte Value = 0;
+  for (byte i = 0; i < 8; i++)
+  {
+    if (digitalRead(kButtonPins[i]))
+    {
+      bitSet(Value, i);
+    }
+  }
+  return Value;
+}
+
+void PanelMux::WriteLEDs(byte Bank, byte LEDMask6)
+{
+  SelectBank(Bank);
+
+  for (byte i = 0; i < 6; i++)
+  {
+    digitalWrite(kLEDPins[i], bitRead(LEDMask6, i) ? HIGH : LOW);
+  }
+}

--- a/PanelMux.h
+++ b/PanelMux.h
@@ -1,0 +1,18 @@
+#ifndef panel_mux_h
+#define panel_mux_h
+
+#include <Arduino.h>
+
+class PanelMux
+{
+public:
+  static void Init();
+  static void SelectBank(byte Bank);
+  static byte ReadButtons(byte Bank);
+  static void WriteLEDs(byte Bank, byte LEDMask6);
+
+private:
+  static bool m_Initialized;
+};
+
+#endif

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Turn RUN LED off when HALT encountered or STOP pressed (see MCP_LEGACY_RUN_LED).
 **May '25** 
 Corrected 74HC595 connections to LEDs (Q0==LED7) in Pins.h schematic. No code change.
 
+**May '26**
+[thomas-emb](https://github.com/thomas-emb) Added (WIP) option to use 2x(6+8) matrix insterad of shift registers.
+
 Schematic (taken from PINS.H)
 ````
 #ifndef pins_h

--- a/ShiftRegisterButtons.cpp
+++ b/ShiftRegisterButtons.cpp
@@ -1,0 +1,70 @@
+#include <Arduino.h>
+#include "PINS.h"
+#include "ShiftRegisterButtons.h"
+
+byte ShiftRegisterButtons::m_pMap[] = // eg logical eBit2 is actually bit6 from the 165
+{
+  0, 1, 6, 7, 4, 5, 2, 3,
+  11, 12, 13, 14, 15, 9, 8, 10
+};
+
+void ShiftRegisterButtons::Init()
+{
+  // prepare the pins which talk to the 165
+  pinMode(PIN_BTN_PL, OUTPUT);
+  pinMode(PIN_BTN_CP, OUTPUT);
+  pinMode(PIN_BTN_Q7, INPUT);
+
+  m_wPrevState = 0xFFFF;
+}
+
+word ShiftRegisterButtons::ShiftIn(int LatchPin, int DataPin, int ClockPin, int BitOrder)
+{
+  // read 16 bits of button statuses
+  digitalWrite(ClockPin, HIGH);
+
+  digitalWrite(LatchPin, LOW);
+  digitalWrite(LatchPin, HIGH);
+
+  byte First = shiftIn(DataPin, ClockPin, BitOrder);
+  byte Second = shiftIn(DataPin, ClockPin, BitOrder);
+  return word(Second, First);
+}
+
+bool ShiftRegisterButtons::GetButtons(word& State, word& NewPressed, bool Wait)
+{
+  word ThisState = ShiftIn(PIN_BTN_PL, PIN_BTN_Q7, PIN_BTN_CP, MSBFIRST);
+
+  if (Wait)
+  {
+    delay(20);
+    word DebouncedState = ShiftIn(PIN_BTN_PL, PIN_BTN_Q7, PIN_BTN_CP, MSBFIRST);
+    if (DebouncedState != ThisState)
+      return false;
+  }
+
+  if (ThisState != m_wPrevState)
+  {
+    NewPressed = ThisState & (~m_wPrevState);
+
+    m_wPrevState = ThisState;
+    State = ThisState;
+    return true;
+  }
+  return false;
+}
+
+bool ShiftRegisterButtons::IsPressed(word BtnState, int Btn)
+{
+  return bitRead(BtnState, m_pMap[Btn]);
+}
+
+bool ShiftRegisterButtons::GetButtonDown(word BtnState, int& Btn)
+{
+  for (Btn = eBit0; Btn <= eUnused; Btn++)
+  {
+    if (IsPressed(BtnState, Btn))
+      return true;
+  }
+  return false;
+}

--- a/ShiftRegisterButtons.h
+++ b/ShiftRegisterButtons.h
@@ -1,0 +1,21 @@
+#ifndef shift_register_buttons_h
+#define shift_register_buttons_h
+
+#include "Buttons.h"
+
+// Shift-register implementation (74HC165 x2).
+class ShiftRegisterButtons : public Buttons
+{
+public:
+  virtual void Init();
+  virtual bool GetButtons(word& State, word& NewPressed, bool deBounce);
+  virtual bool IsPressed(word BtnState, int Btn);
+  virtual bool GetButtonDown(word BtnState, int& Btn);
+
+private:
+  word ShiftIn(int LatchPin, int DataPin, int ClockPin, int BitOrder);
+  static byte m_pMap[];
+  word m_wPrevState;
+};
+
+#endif

--- a/ShiftRegisterLEDs.cpp
+++ b/ShiftRegisterLEDs.cpp
@@ -1,0 +1,64 @@
+#include <Arduino.h>
+#include "PINS.h"
+#include "MCP.h"
+#include "ShiftRegisterLEDs.h"
+
+byte ShiftRegisterLEDs::m_pDirectControlPins[] =
+{
+  PIN_LED_INP,
+  PIN_LED_ADDR,
+  PIN_LED_MEM,
+  PIN_LED_RUN_PWM
+};
+
+void ShiftRegisterLEDs::Init()
+{
+  // the 595 controls the 8 data LEDs
+  pinMode(PIN_LEDS_DS, OUTPUT);
+  pinMode(PIN_LEDS_ST, OUTPUT);
+  pinMode(PIN_LEDS_SH, OUTPUT);
+  ShiftOut(0x00);
+  m_LastData = 0;
+
+  // the 4 control LEDs have a direct link
+  for (int Pin = MCP::eInput; Pin <= MCP::eRun; Pin++)
+  {
+    pinMode(m_pDirectControlPins[Pin], OUTPUT);
+    digitalWrite(m_pDirectControlPins[Pin], LOW);
+  }
+  m_LastControl = 0;
+}
+
+void ShiftRegisterLEDs::ShiftOut(byte LEDs)
+{
+  digitalWrite(PIN_LEDS_ST, LOW);
+  shiftOut(PIN_LEDS_DS, PIN_LEDS_SH, LSBFIRST, LEDs);
+  digitalWrite(PIN_LEDS_ST, HIGH);
+}
+
+void ShiftRegisterLEDs::Display(byte Data, byte Control)
+{
+  if (Data != m_LastData)
+  {
+    ShiftOut(Data);
+    m_LastData = Data;
+  }
+
+  if (Control != m_LastControl)
+  {
+    for (int Pin = MCP::eInput; Pin < MCP::eRun; Pin++)
+    {
+      digitalWrite(m_pDirectControlPins[Pin], bitRead(Control, Pin) ? HIGH : LOW);
+    }
+
+    if (bitRead(Control, MCP::eRun))
+    {
+      analogWrite(m_pDirectControlPins[MCP::eRun], 0xFF - (Control & 0xF0));
+    }
+    else
+    {
+      digitalWrite(m_pDirectControlPins[MCP::eRun], LOW);
+    }
+    m_LastControl = Control;
+  }
+}

--- a/ShiftRegisterLEDs.h
+++ b/ShiftRegisterLEDs.h
@@ -1,0 +1,21 @@
+#ifndef shift_register_leds_h
+#define shift_register_leds_h
+
+#include "LEDS.h"
+
+// Shift-register implementation: 74HC595 for data LEDs + direct control LEDs.
+class ShiftRegisterLEDs : public LEDs
+{
+public:
+  virtual void Init();
+  virtual void Display(byte Data, byte Control);
+
+private:
+  void ShiftOut(byte LEDs);
+
+  static byte m_pDirectControlPins[];
+  byte m_LastData;
+  byte m_LastControl;
+};
+
+#endif


### PR DESCRIPTION
To simplify the Kenbakuino, I designed a matrix implementation. This will get rid of the shift registers, and unless n-key is required (which it isn't) no diodes are needed on the matrix.
The changes are far from done:
- add code to avoid "ghosting"
- clean out code for PWM on the run LED
- Add code to use the unused button for Power (using deep sleep?)
- Add a schematic+PCB to create a Kenbakuino on a single sub-business-card PCB.
If you're not willing to pull this code, or wait until it is a more mature state that's okay.